### PR TITLE
change shortcut, add context menu to open tdo in browser tab

### DIFF
--- a/config/webpack.extension.js
+++ b/config/webpack.extension.js
@@ -33,6 +33,7 @@ var specific = {
             { from: path.join(__dirname, '../assets'), to: path.join(extensionContentPath, '/assets'), ignore: '*.db' },
             { from: path.join(__dirname, '../extension/assets'), to: path.join(extensionContentPath, '/assets'), ignore: '*.db' },
             { from: path.join(__dirname, '../extension/manifest_chrome.json'), to: path.join(extensionContentPath, '/manifest.json') },
+            { from: path.join(__dirname, '../extension/background.js'), to: extensionContentPath },
 			{ from: path.join(extensionSecretsPath, '/chrome.pem'), to: path.join(extensionContentPath, '/key.pem') }
         ]),
         new webpack.optimize.UglifyJsPlugin(),

--- a/extension/background.js
+++ b/extension/background.js
@@ -1,0 +1,18 @@
+try{
+	chrome.contextMenus.create({
+		'id': 'launch_tdo_on_tab',
+		'title': 'Launch on Tab',
+		'contexts': ['browser_action'],
+	});
+	
+	chrome.contextMenus.onClicked.addListener(function(info, tab){
+		console.log(info);
+		switch(info.menuItemId){
+			case 'launch_tdo_on_tab':
+				chrome.tabs.create({ url: 'index.html', active: true });
+				break;
+		}
+	});
+}catch(_err){
+	console.error(_err);
+}

--- a/extension/manifest_chrome.json
+++ b/extension/manifest_chrome.json
@@ -14,7 +14,8 @@
 	},
 	
 	"permissions": [
-		"storage"
+		"storage",
+		"contextMenus"
 	],
 	
 	"content_security_policy": "script-src 'self' 'unsafe-eval' https://cdn.polyfill.io https://unpkg.com; object-src 'self'",
@@ -24,13 +25,16 @@
 		"default_title": "tdo",
 		"default_popup": "index.html"
 	},
-
+	"background": {
+		"persistent": true,
+		"scripts": ["background.js"]
+	},
+	
 	"commands": {
 		"_execute_browser_action": {
 			"description": "Open tdo.",
-			"global": true,
 			"suggested_key": {
-				"default": "Ctrl+Shift+0"
+				"default": "Ctrl+Shift+9"
 			}
 		}
 	}


### PR DESCRIPTION
The cause is unknown, but the `global scope` does not work.
Regardless of the global scope, the `Ctrl+Shift+0` does not work either.

Because, I changed the shortcut.

In addition, I added a menu to open tdo in browser tab instead of `newtab override`.

![context-menu](https://cloud.githubusercontent.com/assets/54208/21757881/68291e50-d678-11e6-9817-a2ca0687179e.png)
