### PR TITLE
fix: prevented event propagation on `task done action`

### DIFF
--- a/app/routes/default/Task.js
+++ b/app/routes/default/Task.js
@@ -136,6 +136,8 @@ class TaskCmp extends VDOM.Component {
 
             case 32: 
             case 88: // x
+                e.stopPropagation();
+                e.preventDefault();
                 this.setCompleted(!data.task.completed);
                 break;
 


### PR DESCRIPTION
very small fix. ;)

There is the little inconvenience of scrolling when the task is completed with the space bar when the list is long.