### PR TITLE
Deleted lists and moving tasks

### DIFF
--- a/app/routes/default/Controller.js
+++ b/app/routes/default/Controller.js
@@ -163,7 +163,7 @@ export default class extends Controller {
         e.stopPropagation();
         e.preventDefault();
         let {tdo, $task} = store.getData();
-        let {lists} = tdo;
+        let lists = tdo.lists.filter(a => !a.deleted);
 
         var boardId = this.getBoardId($task, lists);
         if (boardId == null) return;
@@ -181,7 +181,7 @@ export default class extends Controller {
         e.stopPropagation();
         e.preventDefault();
         let {tdo, $task} = store.getData();
-        let {lists} = tdo;
+        let lists = tdo.lists.filter(a => !a.deleted);
 
         var boardId = this.getBoardId($task, lists);
         if (boardId == null) return;


### PR DESCRIPTION
Hi,
I've noticed that moving tasks between lists caused their vanishing (from GUI) in some scenarios. After some digging I found out that these tasks are still in data store, but they are assigned to lists marked as deleted. Attached fix should handle that.