### PR TITLE
Checkboxes styles at tasks list

### DIFF
--- a/app/routes/default/Task.js
+++ b/app/routes/default/Task.js
@@ -69,17 +69,18 @@ class TaskCmp extends VDOM.Component {
         var html = data.task.name ? marked(data.task.name) : '<p>&nbsp;</p>';
 
         var styles = getStyles(data.task.name, data.styles);
+        var className = widget.CSS.element('checkbox', "input", {
+            checked: !!data.task.completed,
+        });
 
         return [
-            <input key={"check"+data.task.completed}
-                   type="checkbox"
-                   checked={!!data.task.completed}
-                   onChange={::this.onCheck}
-                   tabIndex={-1}
-                   onClick={e=> {
-                       e.preventDefault();
-                       e.stopPropagation();
-                   }}/>,
+            <div className={className} onClick={() => {
+                this.setCompleted(!data.task.completed);
+            }}>
+                <svg className="cxe-checkbox-input-check" viewBox="0 0 64 64">
+                    <path d="M7.136 42.94l20.16 14.784 29.568-40.32-9.72-7.128-22.598 30.816-10.44-7.656z" fill="currentColor"></path>
+                </svg>
+            </div>,
             <div key="content"
                  className={widget.CSS.expand("cxe-task-content", styles.className)}
                  style={styles.style}


### PR DESCRIPTION
Tiny improvement but brings some consistency for the most used view.

Before:
![tdo-list-before](https://user-images.githubusercontent.com/1695878/31748673-0eb51564-b475-11e7-8aa9-7128899eb32a.png)

After:
![tdo-list-after](https://user-images.githubusercontent.com/1695878/31748679-16dc3678-b475-11e7-9b0c-84e56e06f98f.png)
